### PR TITLE
Add nix flake for building

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1738680400,
+        "narHash": "sha256-ooLh+XW8jfa+91F1nhf9OF7qhuA/y1ChLx6lXDNeY5U=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "799ba5bffed04ced7067a91798353d360788b30d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
           pkgs = import nixpkgs {inherit system;};
         });
   in {
-    packages = forAllSystems ({pkgs, ...}: {
+    packages = forAllSystems ({pkgs, ...}: rec {
       default = pkgs.stdenv.mkDerivation {
         pname = "libfprint-goodixtls-55x4";
         version = "r1802-6e4fdc0";
@@ -68,6 +68,9 @@
           license = pkgs.lib.licenses.lgpl21Only;
           platforms = pkgs.lib.platforms.linux;
         };
+      };
+      fprintd = pkgs.fprintd.override {
+        libfprint = default;
       };
     });
   };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,74 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }: let 
+    forAllSystems = f:
+      nixpkgs.lib.genAttrs nixpkgs.lib.platforms.unix (system:
+        f {
+          pkgs = import nixpkgs {inherit system;};
+        });
+  in {
+    packages = forAllSystems ({pkgs, ...}: {
+      default = pkgs.stdenv.mkDerivation {
+        pname = "libfprint-goodixtls-55x4";
+        version = "r1802-6e4fdc0";
+        outputs = [
+          "out"
+          "devdoc"
+        ];
+
+        src = ./.;
+
+        postPatch = ''
+          patchShebangs \
+            tests/test-runner.sh \
+            tests/unittest_inspector.py \
+            tests/virtual-image.py \
+            tests/umockdev-test.py \
+            tests/test-generated-hwdb.sh
+          mkdir -p $out/include/libfprint-2
+          cp -r libfprint/sigfm $out/include/libfprint-2
+        '';
+
+        nativeBuildInputs = with pkgs; [
+          pkg-config
+          meson
+          ninja
+          cmake
+          gtk-doc
+          gdb
+          docbook-xsl-nons
+          gobject-introspection
+        ];
+
+        buildInputs = with pkgs; [
+          gusb
+          glib
+          cairo
+          openssl
+          opencv
+          doctest
+          libgudev
+        ];
+
+        mesonFlags = [
+          "-Dudev_rules_dir=${placeholder "out"}/lib/udev/rules.d"
+          # Include virtual drivers for fprintd tests
+          "-Ddrivers=default"
+          "-Dudev_hwdb_dir=${placeholder "out"}/lib/udev/hwdb.d"
+        ];
+
+        doCheck = false;
+
+        meta = {
+          description = "Fork of libfprint for Goodix TLS 55x4 devices support";
+          homepage = "https://github.com/TheWeirdDev/libfprint";
+          license = pkgs.lib.licenses.lgpl21Only;
+          platforms = pkgs.lib.platforms.linux;
+        };
+      };
+    });
+  };
+}


### PR DESCRIPTION
I had a hard time figuring out how to build this with nix (my laptop has the 55b4 reader) to add this to my nix config. Adding a flake.nix makes building a lot easier. Sadly I wasn't able to make the unit tests work (I didn't want to mess with the code). Most of the nix package is copied from: https://github.com/NixOS/nixpkgs/blob/88a55dffa4d44d294c74c298daf75824dc0aafb5/pkgs/by-name/li/libfprint/package.nix#L92 (The current implementation of the original libfprint in nixpkgs) 