### PR TITLE
goodix55x4: reliable enrollment/unlock on 55b4 (host-side finger detection both directions + fixes)

### DIFF
--- a/libfprint/drivers/goodixtls/goodix55x4.c
+++ b/libfprint/drivers/goodixtls/goodix55x4.c
@@ -61,9 +61,20 @@
 #define GOODIX55X4_FINGER_DETECT_MAX_ATTEMPTS 100
 #define GOODIX55X4_FINGER_DETECT_POLL_DELAY_MS 100
 // Average per-pixel absolute difference (12-bit pixels, 0-4095) needed
-// to call a frame a real touch. Validated against real 55b4 hardware:
-// background noise sits around 4-5, a real touch around 750+.
-#define GOODIX55X4_FINGER_DETECT_DIFF_THRESHOLD 100
+// to call a frame a real touch. On this unit background noise sits at
+// 4-16, a light graze around 145 (too partial to match reliably) and a
+// firm press at 300-780, so only firm presses are accepted.
+#define GOODIX55X4_FINGER_DETECT_DIFF_THRESHOLD 250
+// The FDT-up event is equally unreliable on this firmware, so finger
+// release is also detected host-side. Lower than the touch threshold to
+// get hysteresis; must still be above the lingering-graze level (~145).
+#define GOODIX55X4_FINGER_UP_DIFF_THRESHOLD 100
+// Consecutive above-threshold frames required to accept a capture.
+// Keep at 1: quick taps (the normal unlock gesture) only stay above
+// threshold for a single frame, and the 250 threshold already filters
+// grazes (~145-190) on its own.
+#define GOODIX55X4_FINGER_DETECT_CONFIRM_FRAMES 1
+#define GOODIX55X4_FINGER_DETECT_CONFIRM_DELAY_MS 60
 
 typedef unsigned short Goodix55X4Pix;
 
@@ -74,6 +85,9 @@ struct _FpiDeviceGoodixTls55X4 {
 
   GSList *frames;
   guint poll_attempts;
+  guint confirm_frames;
+  GSource *poll_source;
+  gboolean stopping;
 
   Goodix55X4Pix empty_img[GOODIX55X4_FRAME_SIZE];
 };
@@ -526,8 +540,53 @@ static void save_frame(FpiDeviceGoodixTls55X4 *self, guint8 *raw) {
 }
 
 static void retry_finger_poll(FpDevice *dev, gpointer user_data) {
+  FpiDeviceGoodixTls55X4 *self = FPI_DEVICE_GOODIXTLS55X4(dev);
   FpiSsm *ssm = user_data;
+  self->poll_source = NULL;
+  if (self->stopping)
+    return;
   fpi_ssm_jump_to_state(ssm, SCAN_STAGE_SWITCH_TO_FDT_MODE);
+}
+
+static void retry_finger_up_poll(FpDevice *dev, gpointer user_data) {
+  FpiDeviceGoodixTls55X4 *self = FPI_DEVICE_GOODIXTLS55X4(dev);
+  FpiSsm *ssm = user_data;
+  self->poll_source = NULL;
+  if (self->stopping)
+    return;
+  fpi_ssm_jump_to_state(ssm, SCAN_STAGE_SWITCH_TO_FDT_UP);
+}
+
+static void scan_on_read_img_up(FpDevice *dev, guint8 *data, guint16 len,
+                                gpointer ssm, GError *err) {
+  if (err) {
+    fpi_ssm_mark_failed(ssm, err);
+    return;
+  }
+
+  FpiDeviceGoodixTls55X4 *self = FPI_DEVICE_GOODIXTLS55X4(dev);
+  if (self->stopping)
+    return;
+
+  Goodix55X4Pix candidate[GOODIX55X4_FRAME_SIZE];
+  decode_frame(candidate, data);
+
+  double diff = frame_diff_score(candidate, self->empty_img);
+  g_print("Finger-up poll: diff vs background = %.1f\n", diff);
+
+  if (diff >= GOODIX55X4_FINGER_UP_DIFF_THRESHOLD) {
+    // Finger still on the sensor; poll again. If it never leaves, fall
+    // through to DONE anyway so the state machine can't wedge.
+    if (++self->poll_attempts < GOODIX55X4_FINGER_DETECT_MAX_ATTEMPTS) {
+      self->poll_source =
+          fpi_device_add_timeout(dev, GOODIX55X4_FINGER_DETECT_POLL_DELAY_MS,
+                                 retry_finger_up_poll, ssm, NULL);
+      return;
+    }
+  }
+
+  self->poll_attempts = 0;
+  fpi_ssm_jump_to_state(ssm, SCAN_STAGE_SWITCH_TO_FDT_DONE);
 }
 
 static void scan_on_read_img(FpDevice *dev, guint8 *data, guint16 len,
@@ -539,6 +598,8 @@ static void scan_on_read_img(FpDevice *dev, guint8 *data, guint16 len,
   }
 
   FpiDeviceGoodixTls55X4 *self = FPI_DEVICE_GOODIXTLS55X4(dev);
+  if (self->stopping)
+    return;
 
   Goodix55X4Pix candidate[GOODIX55X4_FRAME_SIZE];
   decode_frame(candidate, data);
@@ -547,18 +608,32 @@ static void scan_on_read_img(FpDevice *dev, guint8 *data, guint16 len,
   g_print("Finger-detect poll: diff vs background = %.1f\n", diff);
 
   if (diff < GOODIX55X4_FINGER_DETECT_DIFF_THRESHOLD) {
+    self->confirm_frames = 0;
     if (++self->poll_attempts >= GOODIX55X4_FINGER_DETECT_MAX_ATTEMPTS) {
       fpi_ssm_mark_failed(ssm,
                          fpi_device_retry_new(FP_DEVICE_RETRY_GENERAL));
       return;
     }
 
-    fpi_device_add_timeout(dev, GOODIX55X4_FINGER_DETECT_POLL_DELAY_MS,
-                           retry_finger_poll, ssm, NULL);
+    self->poll_source =
+        fpi_device_add_timeout(dev, GOODIX55X4_FINGER_DETECT_POLL_DELAY_MS,
+                               retry_finger_poll, ssm, NULL);
+    return;
+  }
+
+  if (++self->confirm_frames < GOODIX55X4_FINGER_DETECT_CONFIRM_FRAMES) {
+    // Finger just landed (or grazed); re-check shortly and only accept
+    // if it is still there.
+    g_print("Finger settle check %u/%u\n", self->confirm_frames,
+            GOODIX55X4_FINGER_DETECT_CONFIRM_FRAMES);
+    self->poll_source =
+        fpi_device_add_timeout(dev, GOODIX55X4_FINGER_DETECT_CONFIRM_DELAY_MS,
+                               retry_finger_poll, ssm, NULL);
     return;
   }
 
   self->poll_attempts = 0;
+  self->confirm_frames = 0;
   save_frame(self, data);
   if (g_slist_length(self->frames) <= GOODIX55X4_CAP_FRAMES) {
     fpi_ssm_jump_to_state(ssm, SCAN_STAGE_SWITCH_TO_FDT_MODE);
@@ -755,10 +830,10 @@ static void scan_run_state(FpiSsm *ssm, FpDevice *dev) {
         sizeof(fdt_switch_state_up_55X4), NULL, check_none_cmd, ssm);
     break;
   case SCAN_STAGE_SWITCH_TO_FDT_UP:
-    g_print("SWITCH TO FDT UP\n");
-    goodix_send_mcu_switch_to_fdt_up(dev, (guint8 *)fdt_switch_state_up_55X4,
-                                     sizeof(fdt_switch_state_up_55X4), NULL,
-                                     check_none_cmd, ssm);
+    // The FDT-up event never fires on some units, so detect finger
+    // release host-side, same as finger-down detection.
+    g_print("WAIT FINGER UP (host-side poll)\n");
+    goodix_tls_read_image(dev, scan_on_read_img_up, ssm);
     break;
   case SCAN_STAGE_SWITCH_TO_FDT_DONE:
     fpi_image_device_report_finger_status(img_dev, FALSE);
@@ -821,6 +896,8 @@ static void sleep_complete(FpiSsm *ssm, FpDevice *dev, GError *error) {
 
 static void scan_start(FpiDeviceGoodixTls55X4 *dev) {
   dev->poll_attempts = 0;
+  dev->confirm_frames = 0;
+  dev->stopping = FALSE;
   fpi_ssm_start(fpi_ssm_new(FP_DEVICE(dev), scan_run_state, SCAN_STAGE_NUM),
                 scan_complete);
 }
@@ -881,6 +958,17 @@ static void dev_change_state(FpImageDevice *img_dev,
 
 static void dev_deactivate(FpImageDevice *img_dev) {
   FpDevice *dev = FP_DEVICE(img_dev);
+  FpiDeviceGoodixTls55X4 *self = FPI_DEVICE_GOODIXTLS55X4(dev);
+
+  // Stop the host-side finger polling before sleeping the device, or a
+  // pending poll fires mid/post-deactivation and wedges the command
+  // pipeline ("A command is already running").
+  self->stopping = TRUE;
+  if (self->poll_source) {
+    g_source_destroy(self->poll_source);
+    self->poll_source = NULL;
+  }
+
   fpi_device_add_timeout(dev, 250, sleep_start, NULL, NULL);
 }
 

--- a/libfprint/drivers/goodixtls/goodix55x4.c
+++ b/libfprint/drivers/goodixtls/goodix55x4.c
@@ -53,6 +53,18 @@
   (GOODIX55X4_HEIGHT * GOODIX55X4_SCAN_WIDTH) / 4 * 6
 #define GOODIX55X4_CAP_FRAMES 1 // Number of frames we capture per swipe
 
+// The MCU's FDT down reply doesn't actually block until a real touch on
+// this firmware - it's an instantaneous check regardless of the
+// configured threshold. Touch detection is done here instead, by
+// polling captured frames and diffing them against the calibration
+// background (empty_img) until real content appears.
+#define GOODIX55X4_FINGER_DETECT_MAX_ATTEMPTS 100
+#define GOODIX55X4_FINGER_DETECT_POLL_DELAY_MS 100
+// Average per-pixel absolute difference (12-bit pixels, 0-4095) needed
+// to call a frame a real touch. Validated against real 55b4 hardware:
+// background noise sits around 4-5, a real touch around 750+.
+#define GOODIX55X4_FINGER_DETECT_DIFF_THRESHOLD 100
+
 typedef unsigned short Goodix55X4Pix;
 
 struct _FpiDeviceGoodixTls55X4 {
@@ -61,6 +73,7 @@ struct _FpiDeviceGoodixTls55X4 {
   guint8 *otp;
 
   GSList *frames;
+  guint poll_attempts;
 
   Goodix55X4Pix empty_img[GOODIX55X4_FRAME_SIZE];
 };
@@ -480,6 +493,16 @@ postprocess_frame(Goodix55X4Pix frame[GOODIX55X4_FRAME_SIZE],
   return sum != 0;
 }
 
+static double
+frame_diff_score(Goodix55X4Pix frame[GOODIX55X4_FRAME_SIZE],
+                 Goodix55X4Pix background[GOODIX55X4_FRAME_SIZE]) {
+  guint64 sum = 0;
+  for (int i = 0; i != GOODIX55X4_FRAME_SIZE; ++i) {
+    sum += ABS((int)frame[i] - (int)background[i]);
+  }
+  return (double)sum / GOODIX55X4_FRAME_SIZE;
+}
+
 typedef struct _frame_processing_info {
   FpiDeviceGoodixTls55X4 *dev;
   GSList **frames;
@@ -502,6 +525,11 @@ static void save_frame(FpiDeviceGoodixTls55X4 *self, guint8 *raw) {
   self->frames = g_slist_append(self->frames, frame);
 }
 
+static void retry_finger_poll(FpDevice *dev, gpointer user_data) {
+  FpiSsm *ssm = user_data;
+  fpi_ssm_jump_to_state(ssm, SCAN_STAGE_SWITCH_TO_FDT_MODE);
+}
+
 static void scan_on_read_img(FpDevice *dev, guint8 *data, guint16 len,
                              gpointer ssm, GError *err) {
   g_print("SCAN_ON_READ_IMG\n");
@@ -511,6 +539,26 @@ static void scan_on_read_img(FpDevice *dev, guint8 *data, guint16 len,
   }
 
   FpiDeviceGoodixTls55X4 *self = FPI_DEVICE_GOODIXTLS55X4(dev);
+
+  Goodix55X4Pix candidate[GOODIX55X4_FRAME_SIZE];
+  decode_frame(candidate, data);
+
+  double diff = frame_diff_score(candidate, self->empty_img);
+  g_print("Finger-detect poll: diff vs background = %.1f\n", diff);
+
+  if (diff < GOODIX55X4_FINGER_DETECT_DIFF_THRESHOLD) {
+    if (++self->poll_attempts >= GOODIX55X4_FINGER_DETECT_MAX_ATTEMPTS) {
+      fpi_ssm_mark_failed(ssm,
+                         fpi_device_retry_new(FP_DEVICE_RETRY_GENERAL));
+      return;
+    }
+
+    fpi_device_add_timeout(dev, GOODIX55X4_FINGER_DETECT_POLL_DELAY_MS,
+                           retry_finger_poll, ssm, NULL);
+    return;
+  }
+
+  self->poll_attempts = 0;
   save_frame(self, data);
   if (g_slist_length(self->frames) <= GOODIX55X4_CAP_FRAMES) {
     fpi_ssm_jump_to_state(ssm, SCAN_STAGE_SWITCH_TO_FDT_MODE);
@@ -772,6 +820,7 @@ static void sleep_complete(FpiSsm *ssm, FpDevice *dev, GError *error) {
 }
 
 static void scan_start(FpiDeviceGoodixTls55X4 *dev) {
+  dev->poll_attempts = 0;
   fpi_ssm_start(fpi_ssm_new(FP_DEVICE(dev), scan_run_state, SCAN_STAGE_NUM),
                 scan_complete);
 }


### PR DESCRIPTION
Makes the 55b4 driver work reliably end-to-end on a Lenovo IdeaPad Flex 5 14ABR8 (`27c6:55b4`, firmware `GF3268_RTSEC_APP_10041`, Linux Mint 22.3 / Ubuntu 24.04 base). Verified with `fprintd-enroll` + `fprintd-verify` (`verify-match`, clean release, no pipeline wedge).

### Note on commits / credit

This branch contains **two** commits:

1. `goodix55x4: add host-side finger detection via frame diff polling` — **authored by @sidevesh**, already proposed in #4. Included here because my fix builds directly on top of it and the two together are what actually makes the sensor usable. Full credit to them for the finger-*down* detection approach.
2. `goodix55x4: detect finger release ...` — my additions (below).

If you'd rather merge #4 first, I can rebase this to contain only my commit.

### What my commit adds

**1. Host-side finger-*release* detection.** Same root cause as finger-down: the FDT-up event never fires on this firmware, so after the first capture the state machine sat in `SWITCH TO FDT UP` forever and enrollment/verification hung. Detect release the same way — poll frames and diff against the calibration background until the finger is gone, with a `MAX_ATTEMPTS` fallthrough to `SCAN_STAGE_SWITCH_TO_FDT_DONE` so it can't wedge if the finger never lifts.

**2. Cancel pending polls on deactivate.** A poll timeout firing during/after `dev_deactivate` re-issued a read and wedged the command pipeline (`A command is already running`), leaving the sensor unresponsive until `fprintd` restarted — this manifested as the lock screen silently doing nothing. Added a `stopping` flag + tracked `GSource` that `dev_deactivate` tears down before sleeping the device.

**3. Threshold tuning.** Measured diff-vs-background on this unit: background noise 4-25, light graze 145-190, lingering print residue after lift 103-108, firm press 300-780. The original touch threshold of 100 accepted grazes and residue, whose partial images always failed matching. Raised touch threshold to 250 and release threshold to 100. Kept capture at a single frame (requiring 2 consecutive frames rejected legitimate quick taps).

The `GOODIX55X4_FINGER_*` constants are unit-calibrated and may want tuning on other hardware — happy to soften them if that's a concern.

Related: sidevesh/libfprint#1 (my commit as a PR against @sidevesh's fork).